### PR TITLE
Add support for MorphMap

### DIFF
--- a/src/PolymorphicField.php
+++ b/src/PolymorphicField.php
@@ -84,7 +84,8 @@ class PolymorphicField extends Field
 
         foreach ($this->meta['types'] as $type) {
 
-            $relatedModel = new $type['value'];
+            $class = Relation::getMorphedModel($type['value']) ?? $type['value'];
+            $relatedModel = new $class;
 
             if($type['value'] == $model->{$this->attribute . '_type'}) {
                 $relatedModel = $relatedModel->newQuery()->findOrFail($model->{$this->attribute . '_id'});
@@ -113,7 +114,8 @@ class PolymorphicField extends Field
 
             if($request->get($attribute) == $type['value']) {
 
-                $relatedModel = new $type['value'];
+                $class = Relation::getMorphedModel($type['value']) ?? $type['value'];
+                $relatedModel = new $class;
 
                 if($type['value'] == $model->{$this->attribute . '_type'}) {
                     $relatedModel = $relatedModel->newQuery()->findOrFail($model->{$this->attribute . '_id'});

--- a/src/PolymorphicField.php
+++ b/src/PolymorphicField.php
@@ -84,7 +84,7 @@ class PolymorphicField extends Field
 
         foreach ($this->meta['types'] as $type) {
 
-            $class = Relation::getMorphedModel($type['value']) ?? $type['value'];
+            $class = array_search($type['value'], Relation::$morphMap) ?? $type['value'];
             $relatedModel = new $class;
 
             if($type['value'] == $model->{$this->attribute . '_type'}) {
@@ -114,7 +114,7 @@ class PolymorphicField extends Field
 
             if($request->get($attribute) == $type['value']) {
 
-                $class = Relation::getMorphedModel($type['value']) ?? $type['value'];
+                $class = array_search($type['value'], Relation::$morphMap) ?? $type['value'];
                 $relatedModel = new $class;
 
                 if($type['value'] == $model->{$this->attribute . '_type'}) {


### PR DESCRIPTION
When using an morphMap to seperate the database with the application structure, we ran into an issue where the `typeClass` must be the class in the application. This adds support for the following:


```
Relation::morphMap([
  'bmw' => \App\Manufacturers\Bmw::class,
  'tesla' => \App\Manufacturers\Tesla::class,
]);

PolymorphicField::make('Typeable')
	->type('BMW', 'bmw', [
	    Text::make('Type', 'name')
	        ->rules('required', 'max:255'),
	])
	->type('Tesla', 'tesla', [
	    Text::make('Type', 'name')
	        ->rules('required', 'max:255'),
	])
```

Unsure at the moment if there's a better way to implement that, so took a stab at it.
