### PR TITLE
Resolve fields to display their correct values

### DIFF
--- a/src/PolymorphicField.php
+++ b/src/PolymorphicField.php
@@ -69,6 +69,10 @@ class PolymorphicField extends Field
 
         foreach ($this->meta['types'] as $index => $type) {
             $this->meta['types'][$index]['active'] = $this->mapToKey($type['value']) == $model->{$this->attribute . '_type'};
+
+            foreach ($type['fields'] as $field) {
+                $field->resolveForDisplay($model->{$this->attribute});
+            }
         }
     }
 


### PR DESCRIPTION
This will ensure that fields show the correctly resolved display value to resolve #8 

E.g. `Select::make('Gender')->options(['male', 'female'])->displayUsingLabels();` will now correctly show `Male` and `Female` instead of `0` and `1` on display/index views.

<img width="1000" alt="Correct display value shown" src="https://user-images.githubusercontent.com/17720020/46290363-86567200-c583-11e8-86c7-29c225d11e1b.png">
