### PR TITLE
Change resolveForDisplay to look for relationship in model

### DIFF
--- a/src/PolymorphicField.php
+++ b/src/PolymorphicField.php
@@ -92,7 +92,8 @@ class PolymorphicField extends Field
             $relatedModel = new $type['value'];
 
             if($this->mapToKey($type['value']) == $model->{$this->attribute . '_type'}) {
-                $relatedModel = $relatedModel->newQuery()->findOrFail($model->{$this->attribute . '_id'});
+                $relatedModel = ($model->{$this->attribute}) ? $model->{$this->attribute}
+                     : $relatedModel->newQuery()->findOrFail($model->{$this->attribute . '_id'});
             }
 
             foreach ($type['fields'] as $field) {


### PR DESCRIPTION
When viewing resource index that leverages the polymorphic field, it will query for the polymorphic relationship per row even if relationship is eager loaded.

Update resolveForDisplay method to look for relationship prior to querying for it.