### PR TITLE
Fix `disableTypeWhenUpdating` in resource edit

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -8,7 +8,7 @@
 					v-model="value"
 					class="w-full form-control form-select"
 					:class="errorClasses"
-					:disabled="disableTypeWhenUpdating ? 'disabled' : ''"
+					:disabled="shouldDisableTypeSelect ? 'disabled' : ''"
 				>
 					<option value="" selected disabled>
 						{{__('Choose an option')}}


### PR DESCRIPTION
Currently, if you create a polymorphic field and disable the type modification, the field will not be disabled. But if you hide it, it disappears.

So this should use the computed property instead of the unavailable data and reenable the ability to disable type modifications