### PR TITLE
Fix display callback for usage with morph maps

### DIFF
--- a/src/PolymorphicField.php
+++ b/src/PolymorphicField.php
@@ -30,7 +30,7 @@ class PolymorphicField extends Field
         $this->displayUsing(function ($value) {
 
             foreach ($this->meta['types'] as $type) {
-                if ($this->mapToKey($type['value']) == $value) {
+                if ($this->mapToKey($type['value']) == $this->mapToKey($value)) {
                     return $type['label'];
                 }
             }


### PR DESCRIPTION
We have an issue that the field isn't shown on the index table. After some debugging we noticed that the $value in the `displayCallback` was the class, but the otherside of the comparison was the name from the morphmap.

This ensures we compare apples with apples 😄 